### PR TITLE
Feat: Sale 등록 백엔드 (잔여차감, 상태전이 (userCard,sale둘다),)

### DIFF
--- a/prisma/migrations/20251211090819_fix_sale/migration.sql
+++ b/prisma/migrations/20251211090819_fix_sale/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "PhotoCard" ALTER COLUMN "price" SET DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "UserCard" ALTER COLUMN "price" SET DEFAULT 0;

--- a/prisma/migrations/20251211123231_update_sale_enum/migration.sql
+++ b/prisma/migrations/20251211123231_update_sale_enum/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userCardId` on the `Sale` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[sellerId,photoCardId]` on the table `Sale` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `genre` to the `Sale` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `grade` to the `Sale` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `photoCardId` to the `Sale` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `Sale` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "SaleGrade" AS ENUM ('COMMON', 'RARE', 'SUPER_RARE', 'LEGENDARY');
+
+-- CreateEnum
+CREATE TYPE "SaleGenre" AS ENUM ('TRAVEL', 'LANDSCAPE', 'PORTRAIT', 'OBJECT');
+
+-- DropForeignKey
+ALTER TABLE "Sale" DROP CONSTRAINT "Sale_userCardId_fkey";
+
+-- AlterTable
+ALTER TABLE "Sale" DROP COLUMN "userCardId",
+ADD COLUMN     "genre" "SaleGenre" NOT NULL,
+ADD COLUMN     "grade" "SaleGrade" NOT NULL,
+ADD COLUMN     "photoCardId" TEXT NOT NULL,
+ADD COLUMN     "quantity" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Sale_sellerId_photoCardId_key" ON "Sale"("sellerId", "photoCardId");
+
+-- AddForeignKey
+ALTER TABLE "Sale" ADD CONSTRAINT "Sale_photoCardId_fkey" FOREIGN KEY ("photoCardId") REFERENCES "UserCard"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251211154808_fix_sale_user_card_id/migration.sql
+++ b/prisma/migrations/20251211154808_fix_sale_user_card_id/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `photoCardId` on the `Sale` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[sellerId,userCardId]` on the table `Sale` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `userCardId` to the `Sale` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Sale" DROP CONSTRAINT "Sale_photoCardId_fkey";
+
+-- DropIndex
+DROP INDEX "Sale_sellerId_photoCardId_key";
+
+-- AlterTable
+ALTER TABLE "Sale" DROP COLUMN "photoCardId",
+ADD COLUMN     "userCardId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Sale_sellerId_userCardId_key" ON "Sale"("sellerId", "userCardId");
+
+-- AddForeignKey
+ALTER TABLE "Sale" ADD CONSTRAINT "Sale_userCardId_fkey" FOREIGN KEY ("userCardId") REFERENCES "UserCard"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -99,19 +99,39 @@ model Sale {
   price       Int
   description String?    @db.Text
   status      SaleStatus @default(ON_SALE)
-  createdAt   DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt   DateTime   @updatedAt @db.Timestamptz(6)
+
+  grade     SaleGrade
+  genre     SaleGenre
+  quantity  Int // 초기 등록 수량 (예시:10장)
+  createdAt DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @db.Timestamptz(6)
 
   seller        User          @relation(fields: [sellerId], references: [id], onDelete: Cascade)
   userCard      UserCard      @relation(fields: [userCardId], references: [id], onDelete: Cascade)
   trade         Trade[]
   saleHistories SaleHistory[] // 판매에 포함된 카드 목록
+
+  @@unique([sellerId, userCardId])
 }
 
 enum SaleStatus {
   ON_SALE
   SOLD_OUT
   CANCELLED
+}
+
+enum SaleGrade {
+  COMMON
+  RARE
+  SUPER_RARE
+  LEGENDARY
+}
+
+enum SaleGenre {
+  TRAVEL
+  LANDSCAPE
+  PORTRAIT
+  OBJECT
 }
 
 model UserCard {

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ import { cors } from './middlewares/cors.js';
 import { errorHandler } from './middlewares/errorHandler.js';
 import authRouter from './routes/authRoute.js';
 import photoCardRouter from './routes/photoCardRouter.js';
+import saleRouter from './routes/saleRouter.js';
 import sellMyPhotoRouter from './routes/sellMyPhotoRouter.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -44,6 +45,7 @@ app.use('/uploads', express.static('uploads'));
 app.use('/auth', authRouter);
 app.use('/cards', photoCardRouter);
 app.use('/sells', sellMyPhotoRouter);
+app.use('/sales', saleRouter);
 
 //-------- router module ---------
 

--- a/src/repositories/photoCardRepository.js
+++ b/src/repositories/photoCardRepository.js
@@ -72,6 +72,30 @@ const photoCardRepository = {
       },
     });
   },
+
+  findUserCards(userId) {
+    return prisma.userCard.findMany({
+      where: { userId },
+      include: {
+        photoCard: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  findUserCardDetail(userId, userCardId) {
+    return prisma.userCard.findUnique({
+      where: {
+        id: userCardId,
+        userId: userId,
+      },
+      include: {
+        user: true,
+        photoCard: true,
+      },
+    });
+  },
 };
 
+// console.log(await prisma.photoCard.findMany({ include: { creator: true, userCards: true } }));
 export default photoCardRepository;

--- a/src/repositories/photoCardRepository.js
+++ b/src/repositories/photoCardRepository.js
@@ -73,29 +73,4 @@ const photoCardRepository = {
     });
   },
 
-  findUserCards(userId) {
-    return prisma.userCard.findMany({
-      where: { userId },
-      include: {
-        photoCard: true,
-      },
-      orderBy: { createdAt: 'desc' },
-    });
-  },
-
-  findUserCardDetail(userId, userCardId) {
-    return prisma.userCard.findUnique({
-      where: {
-        id: userCardId,
-        userId: userId,
-      },
-      include: {
-        user: true,
-        photoCard: true,
-      },
-    });
-  },
-};
-
-// console.log(await prisma.photoCard.findMany({ include: { creator: true, userCards: true } }));
 export default photoCardRepository;

--- a/src/repositories/saleRepository.js
+++ b/src/repositories/saleRepository.js
@@ -5,7 +5,7 @@ const saleRepository = {
    * 특정 판매자의 UserCard를 조회합니다.
    * @param {string} sellerId - 판매자 ID
    * @param {string} userCardId - 포토카드 ID
-   * @param {object} tx - Prisma 트랜잭션 클라이언트
+   * @param {object} tx - saleService에서 받은 트렌젝션 컨텍스트
    * @returns {Promise<object | null>} UserCard 객체
    */
   findUserCard(sellerId, userCardId, tx = prisma) {
@@ -21,7 +21,7 @@ const saleRepository = {
    * UserCard의 수량을 감소시키고 상태를 업데이트합니다.
    * @param {string} userCardId - UserCard의 ID
    * @param {number} newQuantity - 업데이트할 새로운 totalQuantity
-   * @param {object} tx - Prisma 트랜잭션 클라이언트
+   * @param {object} tx - saleService에서 받은 트렌젝션 컨텍스트
    * @returns {Promise<object>} 업데이트된 UserCard 객체
    */
   updateUserCardQuantity(userCardId, newQuantity, tx = prisma) {
@@ -38,7 +38,8 @@ const saleRepository = {
   /**
    * Sale 테이블에 새 판매 항목을 생성합니다.
    * @param {object} data - 판매 등록 데이터
-   * @param {object} tx - Prisma 트랜잭션 클라이언트
+   * @param {object} tx - saleService에서 받은 트렌젝션 컨텍스트
+a 트랜잭션 클라이언트
    * @returns {Promise<object>} 생성된 Sale 객체
    */
   createSale(data, tx = prisma) {

--- a/src/repositories/saleRepository.js
+++ b/src/repositories/saleRepository.js
@@ -1,4 +1,5 @@
 import { prisma } from '../configs/prismaClient.js';
+import { CardStatus, SaleStatus } from '../generated/enums.js';
 
 const saleRepository = {
   /**
@@ -30,7 +31,7 @@ const saleRepository = {
       data: {
         totalQuantity: newQuantity,
         // 등록된 카드가 남아 있다면 OWNED를 유지하거나, 요구사항에 따라 ON_SALE로 변경 가능
-        status: 'ON_SALE',
+        status: CardStatus.ON_SALE,
       },
     });
   },
@@ -46,7 +47,7 @@ a 트랜잭션 클라이언트
     return tx.sale.create({
       data: {
         ...data,
-        status: 'ON_SALE', // Sale 테이블 상태를 ON_SALE로 설정
+        status: SaleStatus.ON_SALE, // Sale 테이블 상태를 ON_SALE로 설정
       },
     });
   },

--- a/src/repositories/saleRepository.js
+++ b/src/repositories/saleRepository.js
@@ -1,0 +1,54 @@
+import { prisma } from '../configs/prismaClient.js';
+
+const saleRepository = {
+  /**
+   * 특정 판매자의 UserCard를 조회합니다.
+   * @param {string} sellerId - 판매자 ID
+   * @param {string} userCardId - 포토카드 ID
+   * @param {object} tx - Prisma 트랜잭션 클라이언트
+   * @returns {Promise<object | null>} UserCard 객체
+   */
+  findUserCard(sellerId, userCardId, tx = prisma) {
+    return tx.userCard.findFirst({
+      where: {
+        userId: sellerId,
+        id: userCardId,
+      },
+    });
+  },
+
+  /**
+   * UserCard의 수량을 감소시키고 상태를 업데이트합니다.
+   * @param {string} userCardId - UserCard의 ID
+   * @param {number} newQuantity - 업데이트할 새로운 totalQuantity
+   * @param {object} tx - Prisma 트랜잭션 클라이언트
+   * @returns {Promise<object>} 업데이트된 UserCard 객체
+   */
+  updateUserCardQuantity(userCardId, newQuantity, tx = prisma) {
+    return tx.userCard.update({
+      where: { id: userCardId },
+      data: {
+        totalQuantity: newQuantity,
+        // 등록된 카드가 남아 있다면 OWNED를 유지하거나, 요구사항에 따라 ON_SALE로 변경 가능
+        status: 'ON_SALE',
+      },
+    });
+  },
+
+  /**
+   * Sale 테이블에 새 판매 항목을 생성합니다.
+   * @param {object} data - 판매 등록 데이터
+   * @param {object} tx - Prisma 트랜잭션 클라이언트
+   * @returns {Promise<object>} 생성된 Sale 객체
+   */
+  createSale(data, tx = prisma) {
+    return tx.sale.create({
+      data: {
+        ...data,
+        status: 'ON_SALE', // Sale 테이블 상태를 ON_SALE로 설정
+      },
+    });
+  },
+};
+
+export default saleRepository;

--- a/src/routes/saleRouter.js
+++ b/src/routes/saleRouter.js
@@ -9,7 +9,15 @@ saleRouter.post('/', auth.verifyAccessToken, async (req, res, next) => {
   const sellerId = req.user.id;
   const { userCardId, quantity, price, description, grade, genre } = req.body;
 
-  if (!userCardId || !quantity || !price || Number(quantity) <= 0 || Number(price) < 0) {
+  if (
+    !userCardId ||
+    !quantity ||
+    !price ||
+    !grade ||
+    !genre ||
+    Number(quantity) <= 0 ||
+    Number(price) < 0
+  ) {
     return res.status(400).json({ message: '핅수 입력  항목이 누락되었거나 유효하지 않습니다.' });
   }
 

--- a/src/routes/saleRouter.js
+++ b/src/routes/saleRouter.js
@@ -18,7 +18,7 @@ saleRouter.post('/', auth.verifyAccessToken, async (req, res, next) => {
     Number(quantity) <= 0 ||
     Number(price) < 0
   ) {
-    return res.status(400).json({ message: '핅수 입력  항목이 누락되었거나 유효하지 않습니다.' });
+    return res.status(400).json({ message: '필수 입력  항목이 누락되었거나 유효하지 않습니다.' });
   }
 
   const saleData = {

--- a/src/routes/saleRouter.js
+++ b/src/routes/saleRouter.js
@@ -1,0 +1,42 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import saleService from '../services/saleService.js';
+
+const saleRouter = express.Router();
+
+saleRouter.post('/', auth.verifyAccessToken, async (req, res, next) => {
+  const sellerId = req.user.id;
+  const { userCardId, quantity, price, description, grade, genre } = req.body;
+
+  if (!userCardId || !quantity || !price || Number(quantity) <= 0 || Number(price) < 0) {
+    return res.status(400).json({ message: '핅수 입력  항목이 누락되었거나 유효하지 않습니다.' });
+  }
+
+  const saleData = {
+    userCardId,
+    quantity: Number(quantity),
+    price: Number(price),
+    description,
+    grade,
+    genre,
+  };
+  try {
+    const newSale = await saleService.registerSale(sellerId, saleData);
+
+    return res.status(201).json({
+      message: '판매 등록이 완료되었습니다.',
+      sale: newSale,
+    });
+  } catch (error) {
+    console.error('판매 등록 오류: ', error.message);
+
+    if (error.message.includes('초과했습니다') || error.message.includes('없습니다')) {
+      return res.status(400).json({ message: error.message });
+    }
+
+    next(error);
+  }
+});
+
+export default saleRouter;

--- a/src/services/saleService.js
+++ b/src/services/saleService.js
@@ -16,6 +16,16 @@ async function registerSale(sellerId, saleData) {
       throw new BadRequestException(`판매 가능 수량(${userCard.totalQuantity}장)을 초과했습니다.`);
     }
 
+    // 중복 판매 등록 여부를 조사하자
+    const existingSale = await saleRepository.findActiveSale(sellerId, userCardId, tx);
+
+    if (existingSale) {
+      throw new BadRequestException(
+        '이미 해당 카드(UserCard)에 대한 판매가 등록 되어있는 상태입니다.  기존 판매를 취소하거나 수정 후 다시 시도해주시기 바랍니다.',
+      );
+    }
+
+    // 검사완료후 차감액션
     const newQuantity = userCard.totalQuantity - quantity;
 
     // 등록된 수만큼 userCard의 totalQuantity가 줄어들게한다.

--- a/src/services/saleService.js
+++ b/src/services/saleService.js
@@ -1,0 +1,47 @@
+import { BadRequestException } from '../common/exceptions/badRequestException.js';
+import { NotFoundException } from '../common/exceptions/notFoundException.js';
+import { prisma } from '../configs/prismaClient.js';
+import saleRepository from '../repositories/saleRepository.js';
+// 나의 판매 포토카드 - 유저 판매 카드 중 판매상태인 카드 목록 조회
+async function registerSale(sellerId, saleData) {
+  const { userCardId, quantity, price, description, grade, genre } = saleData;
+
+  return prisma.$transaction(async (tx) => {
+    console.log('Seller ID:', sellerId);
+    console.log('PhotoCard ID (from request):', userCardId);
+    const userCard = await saleRepository.findUserCard(sellerId, userCardId, tx);
+
+    if (!userCard) {
+      throw new NotFoundException('해당 판매자에게 등록된 카드가 없거나 접근 권한이 없습니다.');
+    }
+    if (userCard.totalQuantity < quantity) {
+      throw new BadRequestException(`판매 가능 수량(${userCard.totalQuantity}장)을 초과했습니다.`);
+    }
+
+    const newQuantity = userCard.totalQuantity - quantity;
+
+    // 등록된 수만큼 userCard의 totalQuantity가 줄어들게한다.
+    await saleRepository.updateUserCardQuantity(userCard.id, newQuantity, tx);
+
+    const newSale = await saleRepository.createSale(
+      {
+        userCardId: userCardId,
+        sellerId: sellerId,
+        quantity: quantity,
+        price: price,
+        description: description,
+        grade: grade,
+        genre: genre,
+      },
+      tx,
+    );
+
+    return newSale;
+  });
+}
+
+const saleService = {
+  registerSale,
+};
+
+export default saleService;

--- a/src/services/saleService.js
+++ b/src/services/saleService.js
@@ -2,13 +2,11 @@ import { BadRequestException } from '../common/exceptions/badRequestException.js
 import { NotFoundException } from '../common/exceptions/notFoundException.js';
 import { prisma } from '../configs/prismaClient.js';
 import saleRepository from '../repositories/saleRepository.js';
-// 나의 판매 포토카드 - 유저 판매 카드 중 판매상태인 카드 목록 조회
+
 async function registerSale(sellerId, saleData) {
   const { userCardId, quantity, price, description, grade, genre } = saleData;
 
   return prisma.$transaction(async (tx) => {
-    console.log('Seller ID:', sellerId);
-    console.log('PhotoCard ID (from request):', userCardId);
     const userCard = await saleRepository.findUserCard(sellerId, userCardId, tx);
 
     if (!userCard) {


### PR DESCRIPTION
## 📌 작업 요약 *
- feat-yk/sale-submit

## 📝 작업 상세 내용 *
- saleRouter sales 엔드포인트시 컨트롤러가 유저인지, 프론트에서 가져온 req.body 에서 데이터를 검사
서비스 로직에서 트렌젝션으로 유저카드를 찾고 갯수가 유저카드의 갯수보다 적으면 예외처리
그다음 userCard의 잔여가 줄어들게 합니다.
그다음 sale테이블을 만들어줍니다.

## 🔍 참고 사항
- sale 페이들에서 cardId로 등록이되며
sellerId 는 등록한 유저의 userId가 등록됩니다.
다만 sale 테이블에서 유저카드를 가져와서 잔여를 차감하기에 현재 까지 완성된 프론트 를 보면서
사용자 입장에서 잔여개수가 맞는지 확인해봐야합니다.

## 🔗 관련 이슈 *
- closes #21 

## ✅ PR 체크 리스트 *
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 기능이 정상 동작하는지 확인했나요?
- [x] 불필요한 console.log나 주석을 제거했나요?
- [x] 머지할 브랜치명을 확인했나요?

## ⚙️ GitHub 설정 안내
- **Assignee**: PR 작성자 본인
- **Reviewers**: 리뷰어 2명 필수 지정
- **Labels**: PR/Issue의 성격, 목적, 상태 표시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카드 판매 등록 기능 추가: 등급(일반/레어/슈퍼레어/레전드), 장르(여행/풍경/초상화/물체), 수량·가격 지정 가능. 재고 차감과 판매 등록이 원자적으로 처리됩니다.
* **API**
  * 판매 등록 엔드포인트 추가: 인증·입력 검증, 한국어 오류 응답 및 적절한 상태 코드 지원.
* **버그 수정**
  * 가격 필드 기본값을 0으로 설정하여 비정상 값 처리 개선.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->